### PR TITLE
feat(MeIR): add configurable ISR toggle to resolve timer conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Makeblock Library v3.29.0 - Updated
+# Makeblock Library v3.29.1 - Updated
 
 Arduino Library for Makeblock Electronic Modules
 
@@ -49,6 +49,26 @@ If you have a discussion about licensing issues, please contact me (myan@makeblo
    Auriga <------->  MeAuriga.h
 
    MegaPi <------->  MeMegaPi.h
+
+### IR receiver / Tone (buzzer) conflict
+
+The library includes an IR receiver implementation (`MeIR`) that uses a hardware timer ISR. Some buzzer/tone libraries (for example `Tone` or `ezBuzzer`) use the same AVR timer and will cause a linker error like:
+
+```
+multiple definition of `__vector_13`
+collect2.exe: error: ld returned 1 exit status
+```
+
+To avoid this conflict you can disable the built-in IR interrupt handler. The library provides a small configuration header `src/MeIR_config.h` with a toggle:
+
+1. Open `src/MeIR_config.h` in the library folder.
+2. Uncomment the line `#define ME_IR_DISABLE_ISR` to disable MeIR's ISR.
+3. Restart the Arduino IDE (or PlatformIO) to force a clean library rebuild.
+
+When `ME_IR_DISABLE_ISR` is defined, the MeIR implementation will not define the timer interrupt vector and will not conflict with other libraries that need that timer. You can still use MeIR's send functions; however, receiving via the built-in ISR will be disabled — you'll need to poll `MeIR::loop()` or use another receiver approach if necessary.
+
+If you prefer not to edit the library each time, create a local patch or a config file under your copy of the library (the repository includes `MeIR_config.h` for that purpose).
+
 
 ## New Features in v3.29.0 - Enhanced MeGyro Class
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MakeBlock Drive Updated
-version=3.29.0
+version=3.29.1
 author=Nick B (Original : Mark Yan), Cégep de Shawinigan
 maintainer=Nick B, Cégep de Shawinigan
 sentence=Use to drive all devices provided by Makeblock company.

--- a/src/MeIR.cpp
+++ b/src/MeIR.cpp
@@ -70,6 +70,8 @@ bool MATCH(uint8_t measured_ticks, uint8_t desired_us)
   return(measured_ticks >= desired_us - (desired_us>>2)-1 && measured_ticks <= desired_us + (desired_us>>2)+1);//判断前后25%的误差
 }
 
+#ifndef ME_IR_DISABLE_ISR
+
 ISR(TIMER_INTR_NAME)
 {
   uint8_t irdata = (uint8_t)digitalRead(2);
@@ -137,6 +139,8 @@ ISR(TIMER_INTR_NAME)
   }
   // irparams.lastTime = new_time;
 }
+
+#endif // !ME_IR_DISABLE_ISR
 
 /**
  * Alternate Constructor which can call your own function to map the IR to arduino port,

--- a/src/MeIR.h
+++ b/src/MeIR.h
@@ -63,9 +63,11 @@
 #include <stdbool.h>
 #include <Arduino.h>
 #include "MeConfig.h"
+#include "MeIR_config.h"
 #ifdef ME_PORT_DEFINED
 #include "MePort.h"
 #endif // ME_PORT_DEFINED
+
 
 #ifndef __AVR_ATmega32U4__
 #define MARK  0
@@ -162,6 +164,9 @@ typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrorStatus;
   TCNT2 = 0; \
 })
 #endif
+
+
+
 
 // information for the interrupt handler
 typedef struct {

--- a/src/MeIR_config.h
+++ b/src/MeIR_config.h
@@ -1,0 +1,7 @@
+// MeIR configuration toggles.
+//
+// If MeIR's timer ISR conflicts with other libraries (Tone, ezBuzzer, ...),
+// uncomment the following line to disable the ISR implementation in MeIR.cpp
+// (the library will not define the timer interrupt vector).
+//
+#define ME_IR_DISABLE_ISR


### PR DESCRIPTION
Add ME_IR_DISABLE_ISR compile-time option to conditionally disable the MeIR interrupt handler, preventing linker errors when using buzzer/tone libraries that require the same AVR timer.

Changes:
- Wrap ISR(TIMER_INTR_NAME) with #ifndef ME_IR_DISABLE_ISR guard
- Include new MeIR_config.h header for configuration
- Document IR/Tone conflict and workaround in README
- Bump version to 3.29.1

This allows users to disable the built-in IR receiver ISR when needed while maintaining backward compatibility by default.